### PR TITLE
Refactoring code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea
 vendor
-bin
 composer.phar
 composer.lock
 phpunit.xml
 /nbproject/*
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: 
-        - TEST_PHPSTAN=true
-    - php: 7.1
       env:
         - TEST_COVERAGE=true
+        - TEST_PHPSTAN=true
     - php: hhvm
       sudo: required
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
   include:
     - php: 7.1
       env: 
+        - TEST_PHPSTAN=true
+    - php: 7.1
+      env:
         - TEST_COVERAGE=true
     - php: hhvm
       sudo: required
@@ -41,6 +44,7 @@ install:
 
 script:
   - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr bin/phpunit --coverage-clover clover.xml; else bin/phpunit; fi;
+  - if [[ $TEST_PHPSTAN ]]; then bin/phpstan analyse -l 7 src fi;
 
 after_success:
   - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover ./clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 
 script:
   - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr bin/phpunit --coverage-clover clover.xml; else bin/phpunit; fi;
-  - if [[ $TEST_PHPSTAN ]]; then bin/phpstan analyse -l 7 src fi;
+  - if [[ $TEST_PHPSTAN ]]; then php ./bin/phpstan analyse -l 7 src fi;
 
 after_success:
   - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover ./clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 
 script:
   - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr bin/phpunit --coverage-clover clover.xml; else bin/phpunit; fi;
-  - if [[ $TEST_PHPSTAN ]]; then php ./bin/phpstan analyse -l 7 src fi;
+  - if [[ $TEST_PHPSTAN ]]; then php ./bin/phpstan analyse -c phpstan.neon -l 7 . fi;
 
 after_success:
   - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover ./clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -10,12 +9,6 @@ env:
   - COMPOSER_FLAGS="--prefer-lowest"
   - COMPOSER_FLAGS=""
 
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.1
-      env:
-        - TEST_COVERAGE=true
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,21 @@ matrix:
   fast_finish: true
   include:
     - php: 7.1
-      env: 
+      env:
         - TEST_COVERAGE=true
+        - TEST_PHPSTAN=true
+    - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest"
+    - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
+      env:
+        - COMPOSER_FLAGS=""
 
 cache:
   directories:
@@ -30,7 +43,9 @@ install:
   - composer update --prefer-dist --no-interaction ${COMPOSER_FLAGS}
 
 script:
+  - if [[ $TEST_PHPSTAN ]]; then php ./bin/phpstan analyse -c phpstan.neon -l 7 . fi;
   - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr bin/phpunit --coverage-clover clover.xml; else bin/phpunit; fi;
+
 
 after_success:
   - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover ./clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ install:
   - composer update --prefer-dist --no-interaction ${COMPOSER_FLAGS}
 
 script:
-  - if [[ $TEST_PHPSTAN ]]; then php ./bin/phpstan analyse -c phpstan.neon -l 7 . fi;
-  - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr bin/phpunit --coverage-clover clover.xml; else bin/phpunit; fi;
+  - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover clover.xml; else vendor/bin/phpunit; fi;
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,25 +16,11 @@ matrix:
     - php: 7.1
       env:
         - TEST_COVERAGE=true
-    - php: hhvm
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - COMPOSER_FLAGS="--prefer-lowest"
-    - php: hhvm
-      sudo: required
-      dist: trusty
-      group: edge
-      env:
-        - COMPOSER_FLAGS=""
-
 cache:
   directories:
     - $HOME/.composer/cache/files
 
 before_install:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi;
   - composer self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ env:
   - COMPOSER_FLAGS="--prefer-lowest"
   - COMPOSER_FLAGS=""
 
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.3
+      env:
+        - TEST_COVERAGE=true
+
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -17,7 +16,6 @@ matrix:
     - php: 7.1
       env:
         - TEST_COVERAGE=true
-        - TEST_PHPSTAN=true
     - php: hhvm
       sudo: required
       dist: trusty

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ style: ## executes php analizers
 
 .PHONY: lint
 lint: ## checks syntax of PHP files
-	docker-compose run --rm --no-deps php sh -lc './vendor/bin/parallel-lint ./ --exclude vendor --exclude bin/.phpunit'
-	docker-compose run --rm --no-deps php sh -lc './bin/console lint:yaml config'
+	./vendor/bin/parallel-lint ./ --exclude vendor --exclude bin/.phpunit
 
 coding-standards: ## Run check and validate code standards tests
 	vendor/bin/ecs check src tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: style
+style: ## executes php analizers
+	./vendor/bin/phpstan analyse -l 6 -c phpstan.neon src tests
+
+.PHONY: lint
+lint: ## checks syntax of PHP files
+	docker-compose run --rm --no-deps php sh -lc './vendor/bin/parallel-lint ./ --exclude vendor --exclude bin/.phpunit'
+	docker-compose run --rm --no-deps php sh -lc './bin/console lint:yaml config'
+
+coding-standards: ## Run check and validate code standards tests
+	vendor/bin/ecs check src tests
+	vendor/bin/phpmd src/ text phpmd.xml
+
+coding-standards-fixer: ## Run code standards fixer
+	vendor/bin/ecs check src tests --fix

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4.3 || ^6.0",
-        "friendsofphp/php-cs-fixer": "^2.3"
+        "friendsofphp/php-cs-fixer": "^2.3",
+        "phpstan/phpstan": "^0.10.3"
     },
     "autoload": {
         "psr-4": { "Facile\\DoctrineMySQLComeBack\\Doctrine\\DBAL\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
     "require-dev": {
         "phpunit/phpunit": "^5.4.3 || ^6.0",
         "friendsofphp/php-cs-fixer": "^2.3",
-        "phpstan/phpstan": "^0.10.3"
+        "phpstan/phpstan": "^0.9",
+        "phpstan/phpstan-phpunit": "^0.9",
+        "jangregor/phpstan-prophecy": "^0.1"
     },
     "autoload": {
         "psr-4": { "Facile\\DoctrineMySQLComeBack\\Doctrine\\DBAL\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php" : "^5.6 || ^7.0",
+        "php" : "^7.0",
         "ext-pdo": "*",
         "doctrine/dbal": "^2.3",
         "psr/log": "^1.0"
@@ -19,7 +19,7 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "mockery/mockery": "^1.2",
         "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan": "^0.8 || ^0.11",
+        "phpstan/phpstan": "^0.9 || ^0.11",
         "phpstan/phpstan-mockery": "^0.11.0",
         "phpstan/phpstan-phpunit": "^0.11",
         "jangregor/phpstan-prophecy": "^0.4.2",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "mockery/mockery": "^1.2",
         "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan": "^0.9 || ^0.11",
         "phpstan/phpstan-mockery": "^0.11.0",
         "phpstan/phpstan-phpunit": "^0.11",
         "jangregor/phpstan-prophecy": "^0.4.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpstan/phpstan-phpunit": "^0.11",
         "jangregor/phpstan-prophecy": "^0.4.2",
         "symplify/easy-coding-standard": "^5.4",
-        "phpunit/phpunit": "7.5.*"
+        "phpunit/phpunit": "^5.4.3 || 7.5.*"
 
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "adgoal/doctrine-mysql-come-back",
     "description": "Auto reconnect on Doctrine MySql has gone away exceptions on doctrine/dbal",
     "keywords": ["mysql","doctrine","reconnect","refresh","connection","has gone away","exception"],
-    "license": "Apache License Version 2.0",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Luca Bo",
@@ -11,14 +11,21 @@
     ],
     "require": {
         "php" : "^5.6 || ^7.0",
+        "ext-pdo": "*",
         "doctrine/dbal": "^2.3",
-        "psr/log": "^1.0",
-        "ext-pdo": "*"
+        "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.4.3 || ^6.0",
-        "friendsofphp/php-cs-fixer": "^2.3",
-        "ext-pdo": "*"
+        "jakub-onderka/php-parallel-lint": "^1.0",
+        "mockery/mockery": "^1.2",
+        "phpmd/phpmd": "^2.6",
+        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan-mockery": "^0.11.0",
+        "phpstan/phpstan-phpunit": "^0.11",
+        "jangregor/phpstan-prophecy": "^0.4.2",
+        "symplify/easy-coding-standard": "^5.4",
+        "phpunit/phpunit": "7.5.*"
+
     },
     "autoload": {
         "psr-4": { "Facile\\DoctrineMySQLComeBack\\Doctrine\\DBAL\\": "src/" }
@@ -27,12 +34,7 @@
         "psr-4": { "Facile\\DoctrineMySQLComeBack\\Doctrine\\DBAL\\": "tests/unit/" }
     },
     "config": {
-        "preferred-install": "dist",
-        "bin-dir": "bin"
+        "preferred-install": "dist"
     },
-    "minimum-stability": "stable",
-    "scripts": {
-        "phpcs": "php-cs-fixer fix --level=psr2 -v --diff --dry-run src/",
-        "phpcs-fix": "php-cs-fixer fix --level=psr2 -v --diff src/"
-    }
+    "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "mockery/mockery": "^1.2",
         "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan": "^0.9 || ^0.11",
+        "phpstan/phpstan": "^0.8 || ^0.11",
         "phpstan/phpstan-mockery": "^0.11.0",
         "phpstan/phpstan-phpunit": "^0.11",
         "jangregor/phpstan-prophecy": "^0.4.2",

--- a/ecs.yml
+++ b/ecs.yml
@@ -1,0 +1,11 @@
+imports:
+  - { resource: 'vendor/symplify/easy-coding-standard/config/clean-code.yml' }
+  - { resource: 'vendor/symplify/easy-coding-standard/config/symfony.yml' }
+  - { resource: 'vendor/symplify/easy-coding-standard/config/common/strict.yml' }
+  - { resource: 'vendor/symplify/easy-coding-standard/config/config.yaml' }
+
+services:
+  PhpCsFixer\Fixer\Operator\ConcatSpaceFixer:
+    spacing: one
+
+parameters:

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Ruleset"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>Ruleset for PHP Mess Detector that enforces coding standards</description>
+
+    <rule ref="rulesets/cleancode.xml">
+        <exclude name="StaticAccess"/>
+    </rule>
+
+    <rule ref="rulesets/codesize.xml"/>
+
+    <rule ref="rulesets/controversial.xml"/>
+
+    <rule ref="rulesets/design.xml"/>
+
+    <rule ref="rulesets/naming.xml">
+        <exclude name="ShortVariable"/>
+        <exclude name="LongVariable"/>
+        <exclude name="ShortMethodName"/>
+    </rule>
+
+    <rule ref="rulesets/unusedcode.xml">
+        <!-- PHPMD cannot recognize parameters that are enforced by an interface -->
+        <exclude name="UnusedFormalParameter"/>
+    </rule>
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/jangregor/phpstan-prophecy/src/extension.neon
+parameters:
+    excludes_analyse:
+        - %rootDir%/../../../vendor/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/jangregor/phpstan-prophecy/src/extension.neon
+    - vendor/phpstan/phpstan-mockery/extension.neon
+parameters:
+    excludes_analyse:
+        - %rootDir%/../../../vendor/*

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -14,6 +14,9 @@ use Doctrine\DBAL\Connection as DBALConnection;
  */
 class Connection extends DBALConnection
 {
+    /** @var ServerGoneAwayExceptionsAwareInterface */
+    protected $_driver;
+
     /** @var int */
     protected $reconnectAttempts = 0;
 
@@ -21,10 +24,10 @@ class Connection extends DBALConnection
     private $selfReflectionNestingLevelProperty;
 
     /**
-     * @param array                                         $params
-     * @param Driver|ServerGoneAwayExceptionsAwareInterface $driver
-     * @param Configuration                                 $config
-     * @param EventManager                                  $eventManager
+     * @param array         $params
+     * @param Driver        $driver
+     * @param Configuration $config
+     * @param EventManager  $eventManager
      *
      * @throws \InvalidArgumentException
      * @throws \Doctrine\DBAL\DBALException
@@ -54,7 +57,7 @@ class Connection extends DBALConnection
      * @param array             $types
      * @param QueryCacheProfile $qcp
      *
-     * @return \Doctrine\DBAL\Driver\Statement The executed statement.
+     * @return \Doctrine\DBAL\Driver\ResultStatement|null The executed statement.
      *
      * @throws \Exception
      */
@@ -87,6 +90,7 @@ class Connection extends DBALConnection
      */
     public function query()
     {
+        /** @var \Doctrine\DBAL\Driver\Statement $stmt */
         $stmt = null;
         $args = func_get_args();
         $attempt = 0;
@@ -129,7 +133,7 @@ class Connection extends DBALConnection
      * @param array  $params
      * @param array  $types
      *
-     * @return integer The number of affected rows.
+     * @return integer|null The number of affected rows.
      *
      * @throws \Exception
      */
@@ -163,7 +167,9 @@ class Connection extends DBALConnection
     public function beginTransaction()
     {
         if (0 !== $this->getTransactionNestingLevel()) {
-            return parent::beginTransaction();
+            parent::beginTransaction();
+
+            return;
         }
 
         $attempt = 0;
@@ -188,7 +194,7 @@ class Connection extends DBALConnection
     }
 
     /**
-     * @param $sql
+     * @param string $sql
      *
      * @return Statement
      */
@@ -200,7 +206,7 @@ class Connection extends DBALConnection
     /**
      * returns a reconnect-wrapper for Statements.
      *
-     * @param $sql
+     * @param string $sql
      *
      * @return Statement
      */
@@ -232,7 +238,7 @@ class Connection extends DBALConnection
     }
 
     /**
-     * @param $attempt
+     * @param int $attempt
      * @param bool $ignoreTransactionLevel
      *
      * @return bool

--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -13,10 +13,12 @@ use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Driver\ServerGoneAwayExceptionsAw
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Events\Args\ReconnectEventArgs;
 use InvalidArgumentException;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionProperty;
+use Throwable;
 
 /**
- * Trait ConnectionTrait
+ * Trait ConnectionTrait.
  */
 trait ConnectionTrait
 {
@@ -30,10 +32,10 @@ trait ConnectionTrait
     protected $forceIgnoreTransactionLevel;
 
     /**
-     * @param array $params
+     * @param array                                         $params
      * @param Driver|ServerGoneAwayExceptionsAwareInterface $driver
-     * @param Configuration $config
-     * @param EventManager $eventManager
+     * @param Configuration                                 $config
+     * @param EventManager                                  $eventManager
      *
      * @throws InvalidArgumentException
      * @throws DBALException
@@ -52,26 +54,26 @@ trait ConnectionTrait
         }
 
         if (isset($params['driverOptions']['x_reconnect_attempts'])) {
-            $this->reconnectAttempts = (int)$params['driverOptions']['x_reconnect_attempts'];
+            $this->reconnectAttempts = (int) $params['driverOptions']['x_reconnect_attempts'];
         }
 
         if (isset($params['driverOptions']['force_ignore_transaction_level'])) {
-            $this->forceIgnoreTransactionLevel = (int)$params['driverOptions']['force_ignore_transaction_level'];
+            $this->forceIgnoreTransactionLevel = (int) $params['driverOptions']['force_ignore_transaction_level'];
         }
 
         parent::__construct($params, $driver, $config, $eventManager);
     }
 
-
     /**
-     * @param string $query
-     * @param array $params
-     * @param array $types
+     * @param string            $query
+     * @param array             $params
+     * @param array             $types
      * @param QueryCacheProfile $qcp
      *
-     * @return \Doctrine\DBAL\Driver\Statement The executed statement.
+     * @return \Doctrine\DBAL\Driver\Statement the executed statement
      *
      * @throws Exception
+     * @throws Throwable
      */
     public function executeQuery($query, array $params = array(), $types = array(), QueryCacheProfile $qcp = null)
     {
@@ -80,6 +82,7 @@ trait ConnectionTrait
         $retry = true;
         while ($retry) {
             $retry = false;
+
             try {
                 $stmt = parent::executeQuery($query, $params, $types, $qcp);
             } catch (Exception $e) {
@@ -92,9 +95,9 @@ trait ConnectionTrait
                         Events\Events::RECONNECT_TO_DATABASE,
                         new ReconnectEventArgs(__FUNCTION__, $attempt, $query)
                     );
-                } else {
-                    throw $e;
                 }
+
+                throw $e;
             }
         }
 
@@ -103,6 +106,7 @@ trait ConnectionTrait
 
     /**
      * @return \Doctrine\DBAL\Driver\Statement
+     *
      * @throws Exception
      */
     public function query()
@@ -113,19 +117,24 @@ trait ConnectionTrait
         $retry = true;
         while ($retry) {
             $retry = false;
+
             try {
                 switch (count($args)) {
                     case 1:
                         $stmt = parent::query($args[0]);
+
                         break;
                     case 2:
                         $stmt = parent::query($args[0], $args[1]);
+
                         break;
                     case 3:
                         $stmt = parent::query($args[0], $args[1], $args[2]);
+
                         break;
                     case 4:
                         $stmt = parent::query($args[0], $args[1], $args[2], $args[3]);
+
                         break;
                     default:
                         $stmt = parent::query();
@@ -151,10 +160,10 @@ trait ConnectionTrait
 
     /**
      * @param string $query
-     * @param array $params
-     * @param array $types
+     * @param array  $params
+     * @param array  $types
      *
-     * @return integer The number of affected rows.
+     * @return int the number of affected rows
      *
      * @throws Exception
      */
@@ -165,6 +174,7 @@ trait ConnectionTrait
         $retry = true;
         while ($retry) {
             $retry = false;
+
             try {
                 $stmt = parent::executeUpdate($query, $params, $types);
             } catch (Exception $e) {
@@ -187,8 +197,8 @@ trait ConnectionTrait
     }
 
     /**
-     * @return void
-     * @throws Exception
+     * @throws ReflectionException
+     * @throws Throwable
      */
     public function beginTransaction()
     {
@@ -200,9 +210,10 @@ trait ConnectionTrait
         $retry = true;
         while ($retry) {
             $retry = false;
+
             try {
                 parent::beginTransaction();
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 if ($this->canTryAgain($attempt, true) && $this->_driver->isGoneAwayException($e)) {
                     $this->close();
                     if (0 < $this->getTransactionNestingLevel()) {
@@ -226,6 +237,7 @@ trait ConnectionTrait
      * @param $sql
      *
      * @return Statement
+     *
      * @throws DBALException
      */
     public function prepare($sql)
@@ -239,6 +251,7 @@ trait ConnectionTrait
      * @param $sql
      *
      * @return Statement
+     *
      * @throws DBALException
      */
     protected function prepareWrapped($sql)
@@ -253,7 +266,9 @@ trait ConnectionTrait
      * @param $sql
      *
      * @return Driver\Statement
+     *
      * @throws DBALException
+     *
      * @internal
      */
     public function prepareUnwrapped($sql)
@@ -283,13 +298,13 @@ trait ConnectionTrait
         $canByAttempt = ($attempt < $this->reconnectAttempts);
         $ignoreTransactionLevel = $this->forceIgnoreTransactionLevel ? true : $ignoreTransactionLevel;
 
-        $canByTransactionNestingLevel = $ignoreTransactionLevel ? true : (0 === $this->getTransactionNestingLevel());
+        $canByTransactionNestingLevel = $ignoreTransactionLevel ? true : 0 === $this->getTransactionNestingLevel();
 
         return $canByAttempt && $canByTransactionNestingLevel;
     }
 
     /**
-     * @param Exception $e
+     * @param Exception   $e
      * @param string|null $query
      *
      * @return bool

--- a/src/ConnectionTrait.php
+++ b/src/ConnectionTrait.php
@@ -45,8 +45,7 @@ trait ConnectionTrait
         Driver $driver,
         Configuration $config = null,
         EventManager $eventManager = null
-    )
-    {
+    ) {
         if (!$driver instanceof ServerGoneAwayExceptionsAwareInterface) {
             throw new InvalidArgumentException(
                 sprintf('%s needs a driver that implements ServerGoneAwayExceptionsAwareInterface', get_class($this))
@@ -75,7 +74,7 @@ trait ConnectionTrait
      * @throws Exception
      * @throws Throwable
      */
-    public function executeQuery($query, array $params = array(), $types = array(), QueryCacheProfile $qcp = null)
+    public function executeQuery($query, array $params = [], $types = [], QueryCacheProfile $qcp = null)
     {
         $stmt = null;
         $attempt = 0;
@@ -167,7 +166,7 @@ trait ConnectionTrait
      *
      * @throws Exception
      */
-    public function executeUpdate($query, array $params = array(), array $types = array())
+    public function executeUpdate($query, array $params = [], array $types = [])
     {
         $stmt = null;
         $attempt = 0;
@@ -322,6 +321,7 @@ trait ConnectionTrait
      * This is required because beginTransaction increment transactionNestingLevel
      * before the real query is executed, and results incremented also on gone away error.
      * This should be safe for a new established connection.
+     *
      * @throws \ReflectionException
      * @throws \ReflectionException
      */

--- a/src/Connections/MasterSlaveConnection.php
+++ b/src/Connections/MasterSlaveConnection.php
@@ -3,11 +3,11 @@
 namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connections;
 
 use Doctrine\DBAL\Connections\MasterSlaveConnection as DBALMasterSlaveConnection;
-use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\ConnectionTrait;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\ConnectionInterface;
+use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\ConnectionTrait;
 
 /**
- * Class MasterSlaveConnection
+ * Class MasterSlaveConnection.
  */
 class MasterSlaveConnection extends DBALMasterSlaveConnection implements ConnectionInterface
 {

--- a/src/Driver/Mysqli/Driver.php
+++ b/src/Driver/Mysqli/Driver.php
@@ -21,6 +21,7 @@ class Driver extends \Doctrine\DBAL\Driver\Mysqli\Driver implements ServerGoneAw
 
     /**
      * {@inheritdoc}
+     *
      * @throws \Doctrine\DBAL\DBALException
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])

--- a/src/Driver/ServerGoneAwayExceptionsAwareTrait.php
+++ b/src/Driver/ServerGoneAwayExceptionsAwareTrait.php
@@ -17,7 +17,7 @@ trait ServerGoneAwayExceptionsAwareTrait
         'Connection refused',
         'Lost connection to MySQL server during query', //code 2013
         'Deadlock found when trying to get lock', //code 1213
-        'Lock wait timeout exceeded' //code 1205
+        'Lock wait timeout exceeded', //code 1205
     ];
 
     /** @var string[] */
@@ -26,7 +26,7 @@ trait ServerGoneAwayExceptionsAwareTrait
         'The MySQL server is running with the --read-only option so it cannot execute this statement',
         'Connection refused',
         'Deadlock found when trying to get lock', //code 1213
-        'Lock wait timeout exceeded' //code 1205
+        'Lock wait timeout exceeded', //code 1205
     ];
 
     /**
@@ -39,7 +39,7 @@ trait ServerGoneAwayExceptionsAwareTrait
         $message = $exception->getMessage();
 
         foreach ($this->goneAwayExceptions as $goneAwayException) {
-            if (stripos($message, $goneAwayException) !== false) {
+            if (false !== stripos($message, $goneAwayException)) {
                 return true;
             }
         }
@@ -57,7 +57,7 @@ trait ServerGoneAwayExceptionsAwareTrait
         $message = $exception->getMessage();
 
         foreach ($this->goneAwayInUpdateExceptions as $goneAwayException) {
-            if (stripos($message, $goneAwayException) !== false) {
+            if (false !== stripos($message, $goneAwayException)) {
                 return true;
             }
         }

--- a/src/Events/Args/ReconnectEventArgs.php
+++ b/src/Events/Args/ReconnectEventArgs.php
@@ -5,8 +5,7 @@ namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Events\Args;
 use Doctrine\Common\EventArgs;
 
 /**
- * Class ReconnectEventArgs
- * @package Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Events\Args
+ * Class ReconnectEventArgs.
  */
 class ReconnectEventArgs extends EventArgs
 {
@@ -34,9 +33,9 @@ class ReconnectEventArgs extends EventArgs
      * ReconnectEventArgs constructor.
      *
      * @param string $function
-     * @param int $attempt
+     * @param int    $attempt
      * @param string $query
-     * @param mixed $args
+     * @param mixed  $args
      */
     public function __construct($function, $attempt, $query, $args = null)
     {
@@ -77,6 +76,4 @@ class ReconnectEventArgs extends EventArgs
     {
         return $this->args;
     }
-
-
 }

--- a/src/Events/EventListener.php
+++ b/src/Events/EventListener.php
@@ -7,12 +7,10 @@ use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Events\Args\ReconnectEventArgs;
 use Psr\Log\LoggerInterface;
 
 /**
- * Class EventListener
- * @package Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Events
+ * Class EventListener.
  */
 class EventListener implements EventSubscriber
 {
-
     /**
      * @var LoggerInterface
      */
@@ -31,14 +29,15 @@ class EventListener implements EventSubscriber
     public function getSubscribedEvents()
     {
         return [
-            Events::RECONNECT_TO_DATABASE
+            Events::RECONNECT_TO_DATABASE,
         ];
     }
 
     /**
      * @param ReconnectEventArgs $args
      */
-    public function reconnectToDatabase(ReconnectEventArgs $args) {
+    public function reconnectToDatabase(ReconnectEventArgs $args)
+    {
         $this->logger->debug(
             '[DOCTRINE][{function}] Retrying query (attempt {attempt}): {query}',
             ['function' => $args->getFunction(), 'attempt' => $args->getAttempt(), 'query' => $args->getQuery()]

--- a/src/Events/Events.php
+++ b/src/Events/Events.php
@@ -2,8 +2,7 @@
 
 namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Events;
 
-
 class Events
 {
-    const RECONNECT_TO_DATABASE ='reconnectToDatabase';
+    const RECONNECT_TO_DATABASE = 'reconnectToDatabase';
 }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -45,13 +45,13 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * @param array|null $params
      *
-     * @return bool|null
+     * @return bool
      *
      * @throws \Exception
      */
     public function execute($params = null)
     {
-        $stmt = null;
+        $stmt = false;
         $attempt = 0;
         $retry = true;
         while ($retry) {

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -24,7 +24,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     protected $conn;
 
     /**
-     * @param $sql
+     * @param string $sql
      * @param Connection $conn
      */
     public function __construct($sql, Connection $conn)
@@ -45,7 +45,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     /**
      * @param array|null $params
      *
-     * @return bool
+     * @return bool|null
      *
      * @throws \Exception
      */
@@ -115,7 +115,7 @@ class Statement implements \IteratorAggregate, DriverStatement
     }
 
     /**
-     * @return int
+     * @return string|int|bool
      */
     public function errorCode()
     {

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -92,7 +92,7 @@ class Statement implements IteratorAggregate, DriverStatement
      */
     public function execute($params = null)
     {
-        $stmt = null;
+        $stmt = false;
         $attempt = 0;
         $retry = true;
         while ($retry) {
@@ -100,7 +100,11 @@ class Statement implements IteratorAggregate, DriverStatement
             try {
                 $stmt = $this->stmt->execute($params);
             } catch (Exception $e) {
-                if ($this->conn->canTryAgain($attempt) && $this->conn->isRetryableException($e, $this->sql)) {
+                if (
+                    $this->conn->canTryAgain($attempt)
+                    &&
+                    $this->conn->isRetryableException($e, $this->sql)
+                ) {
                     $this->conn->close();
                     $this->recreateStatement();
                     ++$attempt;
@@ -173,7 +177,7 @@ class Statement implements IteratorAggregate, DriverStatement
     }
 
     /**
-     * @return int
+     * @return string|int|bool
      */
     public function errorCode()
     {
@@ -252,13 +256,5 @@ class Statement implements IteratorAggregate, DriverStatement
     public function rowCount()
     {
         return $this->stmt->rowCount();
-    }
-
-    /**
-     * @return \Doctrine\DBAL\Statement
-     */
-    public function getWrappedStatement()
-    {
-        return $this->stmt;
     }
 }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -59,6 +59,7 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * Create Statement.
+     *
      * @throws \Doctrine\DBAL\DBALException
      */
     private function createStatement()
@@ -97,6 +98,7 @@ class Statement implements IteratorAggregate, DriverStatement
         $retry = true;
         while ($retry) {
             $retry = false;
+
             try {
                 $stmt = $this->stmt->execute($params);
             } catch (Exception $e) {
@@ -220,8 +222,9 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * @param int|null $fetchMode
-     * @param int $cursorOrientation Only for doctrine/DBAL >= 2.6
-     * @param int $cursorOffset Only for doctrine/DBAL >= 2.6
+     * @param int      $cursorOrientation Only for doctrine/DBAL >= 2.6
+     * @param int      $cursorOffset      Only for doctrine/DBAL >= 2.6
+     *
      * @return mixed
      */
     public function fetch($fetchMode = null, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
@@ -231,8 +234,9 @@ class Statement implements IteratorAggregate, DriverStatement
 
     /**
      * @param int|null $fetchMode
-     * @param int $fetchArgument Only for doctrine/DBAL >= 2.6
-     * @param null $ctorArgs Only for doctrine/DBAL >= 2.6
+     * @param int      $fetchArgument Only for doctrine/DBAL >= 2.6
+     * @param null     $ctorArgs      Only for doctrine/DBAL >= 2.6
+     *
      * @return mixed
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)

--- a/tests/unit/ConnectionTest.php
+++ b/tests/unit/ConnectionTest.php
@@ -29,9 +29,11 @@ class ConnectionTest extends TestCase
             'platform' => $platform->reveal()
         ];
 
+        /** @var Driver $driverReveal */
+        $driverReveal = $driver->reveal();
         $this->connection = new Connection(
             $params,
-            $driver->reveal(),
+            $driverReveal,
             $configuration->reveal(),
             $eventManager->reveal()
         );
@@ -52,9 +54,11 @@ class ConnectionTest extends TestCase
             'platform' => $platform->reveal()
         ];
 
+        /** @var Driver $driverReveal */
+        $driverReveal = $driver->reveal();
         $connection = new Connection(
             $params,
-            $driver->reveal(),
+            $driverReveal,
             $configuration->reveal(),
             $eventManager->reveal()
         );

--- a/tests/unit/StateCacheTest.php
+++ b/tests/unit/StateCacheTest.php
@@ -10,14 +10,13 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
-
 /**
- * Class StateCacheTest
- * @package Facile\DoctrineMySQLComeBack\Doctrine\DBAL
+ * Class StateCacheTest.
  */
 class StateCacheTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
+
     /**
      * @covers \Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement
      *
@@ -30,18 +29,15 @@ class StateCacheTest extends TestCase
         $driverStatementNormal = $this->getDriverStatementMock(false, true);
         $driverStatementError = $this->getDriverStatementMock(true, true, DBALException::class);
 
-
         $connection = $this->getConnectionMock([$sql], $driverStatementError, $driverStatementNormal);
 
         $statement = new Statement($sql, $connection);
 
         $this->assertTrue($statement->execute());
-
     }
 
-
     /**
-     * @param string $arg
+     * @param string          $arg
      * @param DriverStatement $driverError
      * @param DriverStatement $driverNormal
      *
@@ -63,10 +59,8 @@ class StateCacheTest extends TestCase
             ->times(1)
             ->andReturnTrue();
 
-
         $mock->shouldReceive('close')
             ->times(1);
-
 
         $mock->shouldReceive('getEventManager')
             ->andReturn(new EventManager())
@@ -82,12 +76,13 @@ class StateCacheTest extends TestCase
      *
      * @return DriverStatement|Mockery\LegacyMockInterface|MockInterface
      */
-    private function getDriverStatementMock($isError, $stmt, $exception = null) {
+    private function getDriverStatementMock($isError, $stmt, $exception = null)
+    {
         $mock = Mockery::mock(DriverStatement::class);
         $isn = $mock
             ->shouldReceive('execute')
             ->times(1);
-        if($isError) {
+        if ($isError) {
             $isn->andThrow($exception, 'Test', 1);
         } else {
             $isn->andReturn($stmt);
@@ -95,5 +90,4 @@ class StateCacheTest extends TestCase
 
         return $mock;
     }
-
 }

--- a/tests/unit/StateCacheTest.php
+++ b/tests/unit/StateCacheTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL;
+
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+
+/**
+ * Class StateCacheTest
+ * @package Facile\DoctrineMySQLComeBack\Doctrine\DBAL
+ */
+class StateCacheTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+    /**
+     * @covers \Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement
+     *
+     * @throws DBALException
+     */
+    public function test_state_cache_only_changed_on_success()
+    {
+        $sql = 'SELECT :value, :param';
+
+        $driverStatementNormal = $this->getDriverStatementMock(false, true);
+        $driverStatementError = $this->getDriverStatementMock(true, true, DBALException::class);
+
+
+        $connection = $this->getConnectionMock([$sql], $driverStatementError, $driverStatementNormal);
+
+        $statement = new Statement($sql, $connection);
+
+        $this->assertTrue($statement->execute());
+
+    }
+
+
+    /**
+     * @param string $arg
+     * @param DriverStatement $driverError
+     * @param DriverStatement $driverNormal
+     *
+     * @return Connection|Mockery\LegacyMockInterface|MockInterface
+     */
+    private function getConnectionMock($arg, $driverError, $driverNormal)
+    {
+        $mock = Mockery::mock(Connection::class);
+        $mock->shouldReceive('prepareUnwrapped')
+            ->withArgs($arg)
+            ->times(2)
+            ->andReturn($driverError, $driverNormal);
+
+        $mock->shouldReceive('canTryAgain')
+            ->times(1)
+            ->andReturnTrue();
+
+        $mock->shouldReceive('isRetryableException')
+            ->times(1)
+            ->andReturnTrue();
+
+
+        $mock->shouldReceive('close')
+            ->times(1);
+
+
+        $mock->shouldReceive('getEventManager')
+            ->andReturn(new EventManager())
+            ->times(1);
+
+        return $mock;
+    }
+
+    /**
+     * @param $isError
+     * @param $stmt
+     * @param string $exception
+     *
+     * @return DriverStatement|Mockery\LegacyMockInterface|MockInterface
+     */
+    private function getDriverStatementMock($isError, $stmt, $exception = null) {
+        $mock = Mockery::mock(DriverStatement::class);
+        $isn = $mock
+            ->shouldReceive('execute')
+            ->times(1);
+        if($isError) {
+            $isn->andThrow($exception, 'Test', 1);
+        } else {
+            $isn->andReturn($stmt);
+        }
+
+        return $mock;
+    }
+
+}

--- a/tests/unit/StatementBindValueTest.php
+++ b/tests/unit/StatementBindValueTest.php
@@ -1,0 +1,80 @@
+<?php
+namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL;
+
+use Doctrine\DBAL\Statement as DBALStatement;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class StatementBindValueTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function test_bind_value_to_statement($arg1, $arg2, $arg3, $return) {
+        $statmentFake = $this->getDBALStatementMock($return);
+        $statment = new Statement('SELECT 1', $this->getConnectionMock($statmentFake));
+
+        $this->assertEquals($return, $statment->bindValue($arg1, $arg2, $arg3));
+        $this->assertEquals($return, $statment->bindParam($arg1, $arg2, $arg3));
+        $this->assertEquals($return, $statment->setFetchMode($arg1, $arg2, $arg3));
+    }
+
+    /**
+     * @param $return
+     *
+     * @return DBALStatement|Mockery\LegacyMockInterface|Mockery\MockInterface
+     */
+    public function getDBALStatementMock($return) {
+        $mock = Mockery::mock(DBALStatement::class);
+        $mock
+            ->shouldReceive('bindValue')
+            ->times(1)
+            ->andReturn($return);
+        $mock
+            ->shouldReceive('bindParam')
+            ->times(1)
+            ->andReturn($return);
+        $mock
+            ->shouldReceive('setFetchMode')
+            ->times(1)
+            ->andReturn($return);
+
+        return $mock;
+    }
+
+
+    private function getConnectionMock($return) {
+        $mock = Mockery::mock(Connection::class);
+        $mock
+            ->shouldReceive('prepareUnwrapped')
+            ->times(1)
+            ->andReturn($return);
+        return $mock;
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider() {
+        return [
+            [
+                'arg1',
+                'arg2',
+                'arg3',
+                true,
+            ],
+            [
+                'arg1',
+                'arg2',
+                'arg3',
+                false,
+            ],
+
+        ];
+    }
+}

--- a/tests/unit/StatementBindValueTest.php
+++ b/tests/unit/StatementBindValueTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL;
 
 use Doctrine\DBAL\Statement as DBALStatement;
@@ -15,7 +16,8 @@ class StatementBindValueTest extends TestCase
      *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function test_bind_value_to_statement($arg1, $arg2, $arg3, $return) {
+    public function test_bind_value_to_statement($arg1, $arg2, $arg3, $return)
+    {
         $statmentFake = $this->getDBALStatementMock($return);
         $statment = new Statement('SELECT 1', $this->getConnectionMock($statmentFake));
 
@@ -29,7 +31,8 @@ class StatementBindValueTest extends TestCase
      *
      * @return DBALStatement|Mockery\LegacyMockInterface|Mockery\MockInterface
      */
-    public function getDBALStatementMock($return) {
+    public function getDBALStatementMock($return)
+    {
         $mock = Mockery::mock(DBALStatement::class);
         $mock
             ->shouldReceive('bindValue')
@@ -47,20 +50,22 @@ class StatementBindValueTest extends TestCase
         return $mock;
     }
 
-
-    private function getConnectionMock($return) {
+    private function getConnectionMock($return)
+    {
         $mock = Mockery::mock(Connection::class);
         $mock
             ->shouldReceive('prepareUnwrapped')
             ->times(1)
             ->andReturn($return);
+
         return $mock;
     }
 
     /**
      * @return array
      */
-    public function dataProvider() {
+    public function dataProvider()
+    {
         return [
             [
                 'arg1',
@@ -74,7 +79,6 @@ class StatementBindValueTest extends TestCase
                 'arg3',
                 false,
             ],
-
         ];
     }
 }

--- a/tests/unit/StatementTest.php
+++ b/tests/unit/StatementTest.php
@@ -1,7 +1,10 @@
 <?php
 
+namespace Facile\DoctrineMySQLComeBack\Doctrine\DBAL;
+
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement;
+use Prophecy\Argument;
 
 class StatementTest extends \PHPUnit\Framework\TestCase
 {
@@ -10,7 +13,9 @@ class StatementTest extends \PHPUnit\Framework\TestCase
         $sql = 'SELECT 1';
         $connection = $this->prophesize(Connection::class);
         $connection
-            ->prepareUnwrapped($sql)
+            ->prepareUnwrapped(
+                Argument::exact($sql)
+            )
             ->shouldBeCalledTimes(1);
 
         $statement = new Statement($sql, $connection->reveal());

--- a/tests/unit/StatementTest.php
+++ b/tests/unit/StatementTest.php
@@ -6,30 +6,48 @@ use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Statement as DcStatement;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection;
 use Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Statement;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use Psr\Log\NullLogger;
 
 /**
- * Class StatementTest
+ * Class StatementTest.
  */
 class StatementTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @throws DBALException
      */
     public function test_construction()
     {
         $sql = 'SELECT 1';
-        $connection = $this->prophesize(Connection::class);
-        $connection
-            ->prepareUnwrapped($sql)
-            ->shouldBeCalledTimes(1);
+        $connection = $this->getConnectionMock([$sql], null, 1);
 
-        $statement = new Statement($sql, $connection->reveal());
+        $statement = new Statement($sql, $connection);
 
         $this->assertInstanceOf(Statement::class, $statement);
+    }
+
+    /**
+     * @param $arg
+     * @param $result
+     * @param $times
+     *
+     * @return Connection|\Mockery\LegacyMockInterface|MockInterface| Connection
+     */
+    private function getConnectionMock($arg, $result, $times)
+    {
+        $mock = Mockery::mock(Connection::class);
+        $mock->shouldReceive('prepareUnwrapped')
+            ->withArgs($arg)
+            ->times($times)
+            ->andReturn($result);
+
+        return $mock;
     }
 
     /**
@@ -37,7 +55,6 @@ class StatementTest extends TestCase
      */
     public function test_retry()
     {
-        $log = new NullLogger();
         $sql = 'SELECT :param';
         /** @var DriverStatement|ObjectProphecy $driverStatement1 */
         $driverStatement1 = $this->prophesize(DriverStatement::class);
@@ -54,7 +71,6 @@ class StatementTest extends TestCase
             ->getEventManager()
             ->willReturn(new EventManager())
             ->shouldBeCalledTimes(1);
-
 
         $statement = new Statement($sql, $connection->reveal());
 
@@ -164,68 +180,21 @@ class StatementTest extends TestCase
         $this->assertTrue($statement->execute());
     }
 
-    /***
+
+
+    /**
      * @throws DBALException
      */
-    public function test_state_cache_only_changed_on_success()
-    {
-        $sql = 'SELECT :value, :param';
-        /** @var DriverStatement|ObjectProphecy $driverStatement1 */
-        $driverStatement1 = $this->prophesize(DriverStatement::class);
-        /** @var DriverStatement|ObjectProphecy $driverStatement2 */
-        $driverStatement2 = $this->prophesize(DriverStatement::class);
-        /** @var Connection|ObjectProphecy $connection */
-        $connection = $this->prophesize(Connection::class);
-        $connection
-            ->prepareUnwrapped($sql)
-            ->willReturn($driverStatement1->reveal(), $driverStatement2)
-            ->shouldBeCalledTimes(2);
-
-        $connection
-            ->getEventManager()
-            ->willReturn(new EventManager())
-            ->shouldBeCalledTimes(1);
-
-        $statement = new Statement($sql, $connection->reveal());
-
-        $param = 1;
-        $driverStatement1->bindParam('param', $param, PDO::PARAM_INT, null)->willReturn(false)->shouldBeCalledTimes(1);
-        $driverStatement1->bindValue('value', 'foo', PDO::PARAM_STR)->willReturn(false)->shouldBeCalledTimes(1);
-        $driverStatement1->setFetchMode(PDO::FETCH_COLUMN, 1, null)->willReturn(false)->shouldBeCalledTimes(1);
-
-        $this->assertFalse($statement->bindParam('param', $param, PDO::PARAM_INT));
-        $this->assertFalse($statement->bindValue('value', 'foo'));
-        $this->assertFalse($statement->setFetchMode(PDO::FETCH_COLUMN, 1));
-
-        $exception = new DBALException('Test');
-        $driverStatement1->execute(null)->willThrow($exception)->shouldBeCalledTimes(1);
-
-        $connection->canTryAgain(0)->willReturn(true)->shouldBeCalledTimes(1);
-        $connection->isRetryableException($exception, $sql)->willReturn(true)->shouldBeCalledTimes(1);
-
-        // retry
-        $connection->close()->shouldBeCalledTimes(1);
-        $driverStatement2->bindParam(Argument::cetera())->shouldNotBeCalled();
-        $driverStatement2->bindValue(Argument::cetera())->shouldNotBeCalled();
-        $driverStatement2->setFetchMode(Argument::cetera())->shouldNotBeCalled();
-        $driverStatement2->execute(null)->willReturn(true)->shouldBeCalledTimes(1);
-
-        $this->assertTrue($statement->execute());
-    }
-
-
     public function test_execute()
     {
         $sql = 'SELECT 1';
-        $dcStatement = $this->prophesize(DcStatement::class);
-        $dcStatement->execute(['test' => 1])->shouldBeCalledTimes(1)->willReturn(true);
 
-        $connection = $this->mockBaseConnection($sql, $dcStatement->reveal());
+        $dcStatement = $this->getDcStatementMock([['test' => 1]], true, 1);
 
-        $statement = new Statement($sql, $connection->reveal());
-        $this->assertTrue(
-            $statement->execute(['test' => 1])
-        );
+        $connection = $this->getConnectionMock([$sql], $dcStatement, 1);
+
+        $statement = new Statement($sql, $connection);
+        $this->assertTrue($statement->execute(['test' => 1]));
     }
 
     /**
@@ -241,12 +210,11 @@ class StatementTest extends TestCase
         $connection = $this->mockBaseConnection($sql, $dcStatement->reveal());
         $connection->canTryAgain(0)->willReturn(false);
         $connection->close()->shouldNotBeCalled();
-        $connection->isRetryableException(Argument::type(\Exception::class), $sql)->willReturn(false);
+        $connection->isRetryableException(Argument::type(\Throwable::class), $sql)->willReturn(false);
 
         $statement = new Statement($sql, $connection->reveal());
 
-
-        $this->expectException(\Exception::class);
+        $this->expectException(\Throwable::class);
         $statement->execute(['test' => 1]);
     }
 
@@ -268,4 +236,20 @@ class StatementTest extends TestCase
         return $connection;
     }
 
+    /**
+     * @param $arg
+     * @param $result
+     * @param $times
+     *
+     * @return DcStatement|\Mockery\LegacyMockInterface|MockInterface|DcStatement
+     */
+    private function getDcStatementMock($arg, $result, $times) {
+        $mock = Mockery::mock(DcStatement::class);
+        $mock->shouldReceive('execute')
+            ->withArgs($arg)
+            ->times($times)
+            ->andReturn($result);
+
+        return $mock;
+    }
 }

--- a/tests/unit/StatementTest.php
+++ b/tests/unit/StatementTest.php
@@ -180,8 +180,6 @@ class StatementTest extends TestCase
         $this->assertTrue($statement->execute());
     }
 
-
-
     /**
      * @throws DBALException
      */
@@ -243,7 +241,8 @@ class StatementTest extends TestCase
      *
      * @return DcStatement|\Mockery\LegacyMockInterface|MockInterface|DcStatement
      */
-    private function getDcStatementMock($arg, $result, $times) {
+    private function getDcStatementMock($arg, $result, $times)
+    {
         $mock = Mockery::mock(DcStatement::class);
         $mock->shouldReceive('execute')
             ->withArgs($arg)


### PR DESCRIPTION
Refactor unit tests
Add mockery
Add ECS
add linter
upgrade PHPUnit version
Remove support php5.6 because phpstan/phpstan use minimal required 7.0
remove support php7.0 because phpstan/phpstan-mockery use minimal required 7.1